### PR TITLE
Fixes error when using getPdfPreviewImage in a summery field

### DIFF
--- a/src/SimplePdfPreviewImageExtension.php
+++ b/src/SimplePdfPreviewImageExtension.php
@@ -34,9 +34,9 @@ class SimplePdfPreviewImageExtension extends DataExtension
         $url = ltrim($url, '/');
         $pdfFile = Director::getAbsFile($url);
         $pathInfo = pathinfo($pdfFile);
-        if (strtolower($pathInfo['extension']) != 'pdf') {
+        if (!isset($pathInfo['extension']) || strtolower($pathInfo['extension']) != 'pdf') {
             //@Todo if dev then exception? else fail silently
-            return null;
+            return File::create();
         }
         $fileName = $pathInfo['filename'];
 


### PR DESCRIPTION
Sometimes the $pathInfo['extension'] is not set. In those cases an empty file should be returned.