### PR TITLE
Use folder find_or_make on folderToSave

### DIFF
--- a/src/SimplePdfPreviewImageExtension.php
+++ b/src/SimplePdfPreviewImageExtension.php
@@ -51,7 +51,7 @@ class SimplePdfPreviewImageExtension extends DataExtension
         $image = DataObject::get_one(Image::class, "`Name` = '{$saveImage}'");
 
         if (!$image) {
-            $folderObject = DataObject::get_one(Folder::class, "`Name` = '{$this->folderToSave}'");
+            $folderObject = Folder::find_or_make($this->folderToSave);
             if ($folderObject) {
                 if ($this->generator->generatePreviewImage($pdfFile, $tmpFile)) {
                     $image = new Image();


### PR DESCRIPTION
Using folder find_or_make on folderToSave instead of DataObject::get.
Folder will be created and published.
This was not working correctly if overwriting folderToSave in config.yml

I would also suggest to set folderToSave by default to: pdf-previews instead of Uploads folder.

This is what I use to overwrite the setting.
```
---
Name: my-simple-pdf-preview
After: simple-pdf-preview
---
Ivoba\SilverStripe\SimplePdfPreview\SimplePdfPreviewImageExtension:
    dependencies:
      folderToSave: "pdf-previews"
```