### PR TITLE
Fixes issues with basedir restrictions

### DIFF
--- a/src/SimplePdfPreviewImageExtension.php
+++ b/src/SimplePdfPreviewImageExtension.php
@@ -49,7 +49,12 @@ class SimplePdfPreviewImageExtension extends DataExtension
         // Fix illegal characters
         $filter    = FileNameFilter::create();
         $saveImage = $filter->filter($saveImage);
-        $tmpFile   = tempnam("/tmp", "pdf");
+        
+        $tmpDir = $_SERVER["DOCUMENT_ROOT"]."/tmp";
+        if (!file_exists($tmpDir)) {
+            mkdir($tmpDir, 0777, true);
+        }
+        $tmpFile   = tempnam($tmpDir, "pdf");
 
         $image = DataObject::get_one(Image::class, "`Name` = '{$saveImage}'");
 

--- a/src/SimplePdfPreviewImageExtension.php
+++ b/src/SimplePdfPreviewImageExtension.php
@@ -50,11 +50,7 @@ class SimplePdfPreviewImageExtension extends DataExtension
         $filter    = FileNameFilter::create();
         $saveImage = $filter->filter($saveImage);
         
-        $tmpDir = $_SERVER["DOCUMENT_ROOT"]."/tmp";
-        if (!file_exists($tmpDir)) {
-            mkdir($tmpDir, 0777, true);
-        }
-        $tmpFile   = tempnam($tmpDir, "pdf");
+        $tmpDir = tempnam(sys_get_temp_dir(), 'pdf');
 
         $image = DataObject::get_one(Image::class, "`Name` = '{$saveImage}'");
 


### PR DESCRIPTION
Hi, I used this plugin today and noticed that there are errors when basedir restrictions are in place. This change should change the temporary file location from "/tmp" to "*DOCUMENT_ROOT*/tmp"